### PR TITLE
docs: update shiny version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ rfc3987-syntax==1.1.0
 rpds-py==0.30.0
 Send2Trash==2.1.0
 setuptools==82.0.0
-shiny==0.0.0
+shiny==1.4.0
 shinywidgets==0.7.1
 six==1.17.0
 sniffio==1.3.1


### PR DESCRIPTION
The shiny version was originally 0.0.0. Updated it to 1.4.0.