### PR TITLE
AI Assistant tab with querychat interface and data download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ All notable changes to this project will be documented in this file.
 - Added a top-of-dashboard **About this dashboard** section with usage instructions and dataset limitations. @hpalafoxp
 - Added **side-by-side university comparison** charts for employment rate after 6 months, employment rate after 1 year, and average starting salary. @hpalafoxp
 - Added **baseline KPI comparisons** against the global average for the most recent 5 years (2021–2025). @hpalafoxp
+- Added **AI assistant tab** with a querychat natural language interface for filtering the dataset. @apoorva43
+- Added **filtered dataframe output** to the AI assistant tab that updates based on chat queries. @apoorva43
+- Added **CSV download button** to export the querychat-filtered data. @apoorva43
 
 ### [0.3.0] Changed
 
 - Changed the default graduation year filter to the **most recent 5 years**. @hpalafoxp
 - Updated the reset button to restore that 5-year default view. @hpalafoxp
+- Converted app layout from `page_fluid` to `page_navbar` to support multiple tabs. @apoorva43
+- Moved AI tab UI and server logic into a separate `src/ai_tab.py` module for readability. @apoorva43
 
 ### [0.3.0] Fixed
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,9 @@ dependencies:
   - anywidget
   - shiny
   - shinywidgets
+  - pip
+
+  - pip:
+    - querychat
+    - chatlas
+    - python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ shiny==1.4.0
 shinywidgets==0.7.1
 pandas==3.0.1
 vl-convert-python==2.0.0rc1
+chatlas==0.15.2
+python-dotenv==1.2.2
+querychat==0.5.1

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -50,6 +50,7 @@ def ai_tab_ui():
         "AI Assistant",
         ui.layout_sidebar(
             qc.sidebar(),
+            ui.download_button("download_data", "Download filtered data as CSV"),
             ui.card(
                 ui.card_header(ui.output_text("ai_chat_title")),
                 ui.output_data_frame("ai_chat_table"),

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -20,16 +20,23 @@ qc = querychat.QueryChat(
 """,
     data_description="""
 Graduate employability dataset with the following columns:
-- Region: geographic region (e.g. North America, Europe, Asia)
-- Country: country of the university
-- University_Name: name of the university
+- Country: country of the university (21 distinct countries)
+- Region: geographic region (e.g. North America, Europe etc.)
+- University_Name: name of the university (46 distinct categories)
+- Degree_Level: degree type completed (e.g. Bachelor, Master, PhD)
 - Field_of_Study: academic discipline (e.g. Computer Science, Business, Engineering)
-- Degree_Level: Bachelor, Master, PhD, MBA
-- Graduation_Year: year of graduation
-- Employment_Rate_6_Months (%): % of graduates employed within 6 months
-- Employment_Rate_12_Months (%): % of graduates employed within 13 months
-- Average_Starting_Salary_USD: average first-year salary in USD
-- Top_Industry: the industry most graduates from the row entered
+- Graduation_Year: year of graduation (2015-2025)
+- Employment_Rate_6_Months (%): % of graduates employed within 6 months (range: 65.5-99.0)
+- Employment_Rate_12_Months (%): % of graduates employed within 12 months (range: 68.0-100.0)
+- Average_Starting_Salary_USD: average first-year salary in USD (range: -1200 to 189400)
+- Top_Industry: most common industry graduates entered (7 distinct industries)
+- Job_Role: specific professional role (e.g. Data Analyst, Software Engineer)
+- Skill_1: primary in-demand skill associated with the role
+- Skill_2: secondary in-demand skill
+- Skill_3: tertiary in-demand skill
+- Skill_Demand_Score: market demand index for the graduate's skill profile (1-100)
+- Remote_Work_Availability (%): estimated share of roles offering remote work (range: 5-90)
+- Employer_Reputation_Score: employer reputation score (1-100)
 """,
     client=ChatGithub(model="gpt-4.1-mini"),    
 )

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+from shiny import ui, reactive, render
+import querychat
+from chatlas import ChatGithub
+from dotenv import load_dotenv
+import pandas as pd
+
+# Load API keys from .env (project root)
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+raw_data = pd.read_csv("data/processed/processed_data.csv")
+
+qc = querychat.QueryChat(
+    raw_data.copy(),
+    "graduate_employability",
+    greeting="""👋 Ask me anything about graduate employability.
+
+* <span class="suggestion">Filter to Computer Science graduates</span>
+* <span class="suggestion">Which universities have the highest employment rate?</span>
+""",
+    data_description="""
+Graduate employability dataset with the following columns:
+- Region: geographic region (e.g. North America, Europe, Asia)
+- Country: country of the university
+- University_Name: name of the university
+- Field_of_Study: academic discipline (e.g. Computer Science, Business, Engineering)
+- Degree_Level: Bachelor, Master, PhD, MBA
+- Graduation_Year: year of graduation
+- Employment_Rate_6_Months (%): % of graduates employed within 6 months
+- Employment_Rate_12_Months (%): % of graduates employed within 13 months
+- Average_Starting_Salary_USD: average first-year salary in USD
+- Top_Industry: the industry most graduates from the row entered
+""",
+    client=ChatGithub(model="gpt-4.1-mini"),    
+)
+    
+def ai_tab_ui():
+    """
+    add docstring
+    """
+    return ui.nav_panel(
+        "AI Assistant",
+        ui.layout_sidebar(
+            qc.sidebar(),
+            ui.card(
+                ui.card_header(ui.output_text("ai_chat_title")),
+                ui.output_data_frame("ai_chat_table"),
+                full_screen=True,
+            ),
+            fillable=True,
+        ),
+    )
+
+def ai_tab_server(input, output, session):
+    """
+    add docstring
+    """
+    qc_vals = qc.server()
+
+    @output
+    @render.text
+    def ai_chat_title():
+        return qc_vals.title() or "Graduate Employability Dataset"
+    
+    @output
+    @render.data_frame
+    def ai_chat_table():
+        return qc_vals.df()
+    
+    # Expose qc_vals so app.py can use the filtered df
+    return qc_vals

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -77,5 +77,9 @@ def ai_tab_server(input, output, session):
     def ai_chat_table():
         return qc_vals.df()
     
+    @render.download(filename="graduate_employability_filtered.csv")
+    def download_data():
+        yield qc_vals.df().to_csv(index=False)
+    
     # Expose qc_vals so app.py can use the filtered df
     return qc_vals

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -1,11 +1,24 @@
+"""
+AI Assistant Tab for the Graduate Skills Employability Dashboard.
+
+This module contains the querychat-powered AI tab which allows users to
+filter the graduate employability dataset using natural language queries.
+
+Setup: 
+Requires a .env file in the project root with the following key:
+    GITHUB_TOKEN=your_github_token_here
+"""
+
+
 from pathlib import Path
-from shiny import ui, reactive, render
+from shiny import ui, render
 import querychat
 from chatlas import ChatGithub
 from dotenv import load_dotenv
 import pandas as pd
 
 # Load API keys from .env (project root)
+# .env should exist at the root of the directory, not inside src/
 load_dotenv(Path(__file__).parent.parent / ".env")
 
 raw_data = pd.read_csv("data/processed/processed_data.csv")
@@ -54,7 +67,11 @@ FOOTER = ui.p(
     
 def ai_tab_ui():
     """
-    add docstring
+    Return the AI Assistant nav_panel to be added to page_navbar in app.py
+
+    Contains the querychat sidebar for natural language filtering, a download
+    button to export the filtered data as CSV, and a dataframe card showing 
+    the current filtered dataset. 
     """
     return ui.nav_panel(
         "AI Assistant",
@@ -73,7 +90,22 @@ def ai_tab_ui():
 
 def ai_tab_server(input, output, session):
     """
-    add docstring
+    Register all server-side logic for the AI Assistant tab.
+
+    Calls qc.server() to initialize the querychat reactive values, then
+    wires up the dataframe output, the card title, and the CSV download
+    handler. Returns qc_vals so callers can access the filtered dataframe.
+
+    Parameters
+    ----------
+    input, output, session: Shiny session objects
+        Passed in from the main server() function in app.py
+
+    Returns
+    -------
+    qc_vals: querychat reactive values
+        Exposes qc_vals.df() (filtered dataframe) and qc_vals.title()
+        for use in app.py if needed.
     """
     qc_vals = qc.server()
 

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -67,12 +67,10 @@ def ai_tab_server(input, output, session):
     """
     qc_vals = qc.server()
 
-    @output
     @render.text
     def ai_chat_title():
         return qc_vals.title() or "Graduate Employability Dataset"
     
-    @output
     @render.data_frame
     def ai_chat_table():
         return qc_vals.df()

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -33,6 +33,14 @@ Graduate employability dataset with the following columns:
 """,
     client=ChatGithub(model="gpt-4.1-mini"),    
 )
+
+FOOTER = ui.p(
+    "Graduate employability dashboard"
+    " | Authors: Wesley Beard, Harrison Li, Hector Palafox Prieto, Apoorva Srivastava |"
+    " Repository: https://github.com/UBC-MDS/DSCI-532_2026_12_GradSkills |"
+    " Last updated: 2026-03-05",
+    class_="text-center text-muted",
+)
     
 def ai_tab_ui():
     """
@@ -49,6 +57,7 @@ def ai_tab_ui():
             ),
             fillable=True,
         ),
+        FOOTER,
     )
 
 def ai_tab_server(input, output, session):

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -15,8 +15,11 @@ qc = querychat.QueryChat(
     "graduate_employability",
     greeting="""👋 Ask me anything about graduate employability.
 
-* <span class="suggestion">Filter to Computer Science graduates</span>
-* <span class="suggestion">Which universities have the highest employment rate?</span>
+* <span class="suggestion">Which universities have the highest 12-month employment rate?</span>
+* <span class="suggestion">Compare starting salaries across degree levels</span>
+* <span class="suggestion">Filter to Technology industry graduates after 2020</span>
+* <span class="suggestion">Show me PhD graduates with salary above 80000</span>
+* <span class="suggestion">Which fields of study have the best 6-month employment rates?</span>
 """,
     data_description="""
 Graduate employability dataset with the following columns:

--- a/src/app.py
+++ b/src/app.py
@@ -162,155 +162,157 @@ salary_baseline = baseline_data["Average_Starting_Salary_USD"].mean()
 
 
 app_ui = ui.page_navbar(
-    #ui.nav_title("Dashboard"),
-    ui.accordion(
-        ui.accordion_panel(
-            "About this dashboard",
-            ui.card(
-                ui.markdown(dashboard_description)
-            ),
-        ),
-    ),
-    ui.layout_sidebar(
-        ui.sidebar(
-            ui.accordion(
-                ui.accordion_panel(
-                    "Region",
-                    (
-                        ui.input_checkbox_group(
-                            id="region",
-                            label="Region",
-                            choices=regions,
-                            selected=regions,
-                        )
-                    ),
-                ),
-                ui.accordion_panel(
-                    "Country",
-                    (
-                        ui.input_checkbox_group(
-                            id="country",
-                            label="Country",
-                            choices=[],
-                            selected=[],
-                        )
-                    ),
-                ),
-                ui.accordion_panel(
-                    "Field of Study",
-                    (
-                        ui.input_checkbox_group(
-                            id="study",
-                            label="Study",
-                            choices=studies,
-                            selected=studies,
-                        )
-                    ),
-                ),
-                ui.accordion_panel(
-                    "Degree Level",
-                    (
-                        ui.input_checkbox_group(
-                            id="degree",
-                            label="Degree",
-                            choices=degrees,
-                            selected=degrees,
-                        )
-                    ),
-                ),
-                ui.accordion_panel(
-                    "Industry",
-                    (
-                        ui.input_checkbox_group(
-                            id="industry",
-                            label="Industry",
-                            choices=industries,
-                            selected=industries,
-                        )
-                    ),
-                ),
-                open=False
-                
-            ),
-            ui.input_slider(
-                id="grad_year",
-                label="Graduation Year",
-                min=raw_data["Graduation_Year"].min(),
-                max=raw_data["Graduation_Year"].max(),
-                value=[
-                    raw_data["Graduation_Year"].max() - 4,
-                    raw_data["Graduation_Year"].max(),
-                ],
-                step=1,
-                ticks=True,
-                animate=True,
-                sep="",
-            ),
-            ui.input_action_button("reset_btn", "Reset Filters"),
-            width=300
-        ),
-        ui.layout_columns(
-            ui.output_ui("emp_rate_6"),
-            ui.output_ui("emp_rate_12"),
-            ui.output_ui("starting_salary"),
-            fill=False,
-        ),
-        ui.layout_columns(
-            ui.card(
-                ui.card_header("Top Universities"),
-                ui.input_action_button("clear_uni_selection", "Clear selected rows"),
-                ui.output_data_frame("university_table"),
-                full_screen=True,
-            ),
-            ui.layout_column_wrap(
+    ui.nav_panel("Dashboard",
+        ui.accordion(
+            ui.accordion_panel(
+                "About this dashboard",
                 ui.card(
-                    ui.card_header("Industries"),
-                    output_widget("industries_bar"),
+                    ui.markdown(dashboard_description)
+                ),
+            ),
+        ),
+        ui.layout_sidebar(
+            ui.sidebar(
+                ui.accordion(
+                    ui.accordion_panel(
+                        "Region",
+                        (
+                            ui.input_checkbox_group(
+                                id="region",
+                                label="Region",
+                                choices=regions,
+                                selected=regions,
+                            )
+                        ),
+                    ),
+                    ui.accordion_panel(
+                        "Country",
+                        (
+                            ui.input_checkbox_group(
+                                id="country",
+                                label="Country",
+                                choices=[],
+                                selected=[],
+                            )
+                        ),
+                    ),
+                    ui.accordion_panel(
+                        "Field of Study",
+                        (
+                            ui.input_checkbox_group(
+                                id="study",
+                                label="Study",
+                                choices=studies,
+                                selected=studies,
+                            )
+                        ),
+                    ),
+                    ui.accordion_panel(
+                        "Degree Level",
+                        (
+                            ui.input_checkbox_group(
+                                id="degree",
+                                label="Degree",
+                                choices=degrees,
+                                selected=degrees,
+                            )
+                        ),
+                    ),
+                    ui.accordion_panel(
+                        "Industry",
+                        (
+                            ui.input_checkbox_group(
+                                id="industry",
+                                label="Industry",
+                                choices=industries,
+                                selected=industries,
+                            )
+                        ),
+                    ),
+                    open=False
+                    
+                ),
+                ui.input_slider(
+                    id="grad_year",
+                    label="Graduation Year",
+                    min=raw_data["Graduation_Year"].min(),
+                    max=raw_data["Graduation_Year"].max(),
+                    value=[
+                        raw_data["Graduation_Year"].max() - 4,
+                        raw_data["Graduation_Year"].max(),
+                    ],
+                    step=1,
+                    ticks=True,
+                    animate=True,
+                    sep="",
+                ),
+                ui.input_action_button("reset_btn", "Reset Filters"),
+                width=300
+            ),
+            ui.layout_columns(
+                ui.output_ui("emp_rate_6"),
+                ui.output_ui("emp_rate_12"),
+                ui.output_ui("starting_salary"),
+                fill=False,
+            ),
+            ui.layout_columns(
+                ui.card(
+                    ui.card_header("Top Universities"),
+                    ui.input_action_button("clear_uni_selection", "Clear selected rows"),
+                    ui.output_data_frame("university_table"),
                     full_screen=True,
                 ),
-                ui.card(
-                    ui.card_header("Yearly Starting Salary for each Field of Study"),
-                    output_widget("study_salary_plot"),
-                    full_screen=True,
-                ),
-                width=1,
-                fill=True,
-            ),
-        ),
-        ui.layout_columns(
-            ui.card(
-                ui.card_header("Side-by-side University comparison"),
                 ui.layout_column_wrap(
                     ui.card(
-                        ui.card_header("Employment Rate (after 6 months)"),
-                        output_widget("uni_emp_rate_6"),
+                        ui.card_header("Industries"),
+                        output_widget("industries_bar"),
                         full_screen=True,
                     ),
                     ui.card(
-                        ui.card_header("Employment Rate (after 1 year)"),
-                        output_widget("uni_emp_rate_12"),
+                        ui.card_header("Yearly Starting Salary for each Field of Study"),
+                        output_widget("study_salary_plot"),
                         full_screen=True,
                     ),
-                    ui.card(
-                        ui.card_header("Average Yearly Starting Salary"),
-                        output_widget("uni_salary"),
-                        full_screen=True,
-                    ),
+                    width=1,
+                    fill=True,
+                ),
+            ),
+            ui.layout_columns(
+                ui.card(
+                    ui.card_header("Side-by-side University comparison"),
+                    ui.layout_column_wrap(
+                        ui.card(
+                            ui.card_header("Employment Rate (after 6 months)"),
+                            output_widget("uni_emp_rate_6"),
+                            full_screen=True,
+                        ),
+                        ui.card(
+                            ui.card_header("Employment Rate (after 1 year)"),
+                            output_widget("uni_emp_rate_12"),
+                            full_screen=True,
+                        ),
+                        ui.card(
+                            ui.card_header("Average Yearly Starting Salary"),
+                            output_widget("uni_salary"),
+                            full_screen=True,
+                        ),
+                    )
                 )
-            )
-        )
+            ),
+        ),
     ),
     ai_tab_ui(),
     title="Graduate Skills Employability Dashboard",
-    footer=ui.p(
-        (
-            "Graduate employability dashboard"
-            " | Authors: Wesley Beard, Harrison Li, Hector Palafox Prieto, Apoorva Srivastava |"
-            " Repository: https://github.com/UBC-MDS/DSCI-532_2026_12_GradSkills |"
-            " Last updated: 2026-02-28"
-        ),
-        class_="text-center text-muted",
-    )
+    #footer=ui.p(
+    #    (
+    #        "Graduate employability dashboard"
+    #        " | Authors: Wesley Beard, Harrison Li, Hector Palafox Prieto, Apoorva Srivastava |"
+    #        " Repository: https://github.com/UBC-MDS/DSCI-532_2026_12_GradSkills |"
+    #        " Last updated: 2026-02-28"
+    #    ),
+    #    class_="text-center text-muted",
+    #    )
+    #)
 )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -162,7 +162,7 @@ salary_baseline = baseline_data["Average_Starting_Salary_USD"].mean()
 
 
 app_ui = ui.page_navbar(
-    ui.nav_title("Dashboard"),
+    #ui.nav_title("Dashboard"),
     ui.accordion(
         ui.accordion_panel(
             "About this dashboard",

--- a/src/app.py
+++ b/src/app.py
@@ -2,9 +2,14 @@
 import numpy as np
 import pandas as pd
 import altair as alt
+from dotenv import load_dotenv
 from shiny import App, render, ui, reactive, req
 from shinywidgets import render_altair, render_widget, output_widget
 from pathlib import Path
+
+from ai_tab import ai_tab_ui, ai_tab_server
+
+load_dotenv(Path(__file__).parent.parent / ".env")
 
 raw_data = pd.read_csv("data/processed/processed_data.csv")
 dashboard_description = Path("src/dashboard_description.md").read_text(encoding="utf-8")
@@ -156,8 +161,8 @@ salary_baseline = baseline_data["Average_Starting_Salary_USD"].mean()
 
 
 
-app_ui = ui.page_fluid(
-    ui.panel_title("Graduate Skills Employability Dashboard"),
+app_ui = ui.page_navbar(
+    ui.nav_title("Dashboard"),
     ui.accordion(
         ui.accordion_panel(
             "About this dashboard",
@@ -295,8 +300,9 @@ app_ui = ui.page_fluid(
             )
         )
     ),
-    ui.hr(),
-    ui.p(
+    ai_tab_ui(),
+    title="Graduate Skills Employability Dashboard",
+    footer=ui.p(
         (
             "Graduate employability dashboard"
             " | Authors: Wesley Beard, Harrison Li, Hector Palafox Prieto, Apoorva Srivastava |"
@@ -309,6 +315,8 @@ app_ui = ui.page_fluid(
 
 
 def server(input, output, session):
+
+    ai_tab_server(input, output, session)
 
     def generate_uni_plot(col, col_title, col_style, col_format):
 

--- a/src/app.py
+++ b/src/app.py
@@ -159,7 +159,13 @@ emp_12_baseline = baseline_data["Employment_Rate_12_Months (%)"].mean()
 salary_baseline = baseline_data["Average_Starting_Salary_USD"].mean()
 
 
-
+FOOTER = ui.p(
+    "Graduate employability dashboard"
+    " | Authors: Wesley Beard, Harrison Li, Hector Palafox Prieto, Apoorva Srivastava |"
+    " Repository: https://github.com/UBC-MDS/DSCI-532_2026_12_GradSkills |"
+    " Last updated: 2026-03-05",
+    class_="text-center text-muted",
+)
 
 app_ui = ui.page_navbar(
     ui.nav_panel("Dashboard",
@@ -300,6 +306,7 @@ app_ui = ui.page_navbar(
                 )
             ),
         ),
+        FOOTER, 
     ),
     ai_tab_ui(),
     title="Graduate Skills Employability Dashboard",


### PR DESCRIPTION
Hey guys! I've added a new AI Assistant tab to the dashboard, so users can filter the data using natural language queries.

Here's what's included:
- Added `src/ai_tab.py` with all the AI tab UI and server logic
- Natural language chat interface for filtering the dataset
- Filtered dataframe output that updates based on chat queries
- CSV download button to export the filtered data
- Added new dependencies to `environment.yml` and `requirements.txt`

Note: using GitHub Models (`gpt-4.1-mini`) via `GITHUB_TOKEN` for now while we verify everything works - will swap to the Anthropic key once we're done with the code.

Closes #62, #63 and #64