### PR TITLE
Shiny version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### [0.3.0] Fixed
 
 - Improved selected-university handling so comparison charts still render a meaningful overall view when no rows are selected. @hpalafoxp
+- Bumped `shiny` to `1.5.1` in `requirements.txt` to resolve dependency conflict with `querychat==0.5.1`. @apoorva43
 
 ### [0.3.0] Known Issues
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 altair==6.0.0
 anywidget==0.9.21
-shiny==1.4.0
+shiny==1.5.1
 shinywidgets==0.7.1
 pandas==3.0.1
 vl-convert-python==2.0.0rc1

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,4 @@
-
+import sys
 import numpy as np
 import pandas as pd
 import altair as alt
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from shiny import App, render, ui, reactive, req
 from shinywidgets import render_altair, render_widget, output_widget
 from pathlib import Path
-
+sys.path.insert(0, str(Path(__file__).parent))
 from ai_tab import ai_tab_ui, ai_tab_server
 
 load_dotenv(Path(__file__).parent.parent / ".env")


### PR DESCRIPTION
Hey guys! I noticed two issues when trying to deploy the app on Posit Connect:
- `querychat==0.5.1` requires `shiny>=1.5.1` but we had `shiny==1.4.0` pinned - bumped it to `1.5.1` in `requirements.txt` to fix the dependency conflict.
- Posit Connect couldn't find `ai_tab.py` because it runs from the project root rather than `src/` - fixed by adding `sys.path` insert in `app.py` so it can locate the module regardless of where the app is launched from.

Confirmed working at: [https://019cbf42-5001-ae88-d367-c997f13a1d3b.share.connect.posit.cloud/](https://019cbf42-5001-ae88-d367-c997f13a1d3b.share.connect.posit.cloud/)
