### PR TITLE
LLM outputs integration and main page improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 - Added **AI assistant tab** with a querychat natural language interface for filtering the dataset. @apoorva43
 - Added **filtered dataframe output** to the AI assistant tab that updates based on chat queries. @apoorva43
 - Added **CSV download button** to export the querychat-filtered data. @apoorva43
+- Added **Top Industries** and **Average Yearly Salary** charts to AI assistant tab that filters based on question asked and query results - from main page with stylistic updates. @beardw
+- Added **Collapseable Toggle** to allow users to open or close all filters at once. @beardw
+- Added **Select All** option to all checkbox filters, except for 'degree_level'. @beardw
 
 ### [0.3.0] Changed
 
@@ -19,6 +22,13 @@ All notable changes to this project will be documented in this file.
 - Updated the reset button to restore that 5-year default view. @hpalafoxp
 - Converted app layout from `page_fluid` to `page_navbar` to support multiple tabs. @apoorva43
 - Moved AI tab UI and server logic into a separate `src/ai_tab.py` module for readability. @apoorva43
+- Changed the layout of the AI Assistant page to have the table on left and charts stacked on right. @beardw
+- Moved reset filter button to top of filters to prevent it being hidden if several filters are open. @beardw
+- Made the 'About Me' description collapsed on load to prevent users from having to do this each time. @beardw
+
+### [0.3.0] Removed
+
+- Removed duplicated checkbox filter name that appeared when opening the dropdown. @beardw
 
 ### [0.3.0] Fixed
 
@@ -31,10 +41,13 @@ All notable changes to this project will be documented in this file.
 - Some universities appear only in certain, non-consecutive years.
 - **Top Industry** is constrained by **Field of Study**.
 - The baseline is a **global benchmark**, not a filter-specific peer baseline.
+- Unselecting all in any one of the checkbox filters will leave dashboard blank.
 
 ### [0.3.0] Reflection
 
 The dashboard now does a better job supporting exploration and direct comparison. Users can filter the data, compare one or more universities, and interpret results against a recent global benchmark. Current limitations come from the data set itself, including limited university coverage and uneven year availability.
+
+
 
 ## [v0.2.0] - 2026-02-28
 

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -16,6 +16,8 @@ import querychat
 from chatlas import ChatGithub
 from dotenv import load_dotenv
 import pandas as pd
+import altair as alt
+from shinywidgets import render_altair, render_widget, output_widget
 
 # Load API keys from .env (project root)
 # .env should exist at the root of the directory, not inside src/
@@ -54,7 +56,7 @@ Graduate employability dataset with the following columns:
 - Remote_Work_Availability (%): estimated share of roles offering remote work (range: 5-90)
 - Employer_Reputation_Score: employer reputation score (1-100)
 """,
-    client=ChatGithub(model="gpt-4.1-mini"),    
+    client=ChatGithub(model="gpt-4.1-mini"),
 )
 
 FOOTER = ui.p(
@@ -64,29 +66,53 @@ FOOTER = ui.p(
     " Last updated: 2026-03-05",
     class_="text-center text-muted",
 )
-    
+
 def ai_tab_ui():
     """
     Return the AI Assistant nav_panel to be added to page_navbar in app.py
 
     Contains the querychat sidebar for natural language filtering, a download
     button to export the filtered data as CSV, and a dataframe card showing 
-    the current filtered dataset. 
+    the current filtered dataset.
     """
+
     return ui.nav_panel(
         "AI Assistant",
-        ui.layout_sidebar(
-            qc.sidebar(),
-            ui.download_button("download_data", "Download filtered data as CSV"),
-            ui.card(
-                ui.card_header(ui.output_text("ai_chat_title")),
-                ui.output_data_frame("ai_chat_table"),
-                full_screen=True,
+        ui.page_fillable(
+            ui.layout_sidebar(
+                qc.sidebar(),
+
+                ui.layout_columns(
+                    ui.card(
+                        ui.card_header(
+                            ui.output_text("ai_chat_title"),
+                            ui.download_button("download_data", "Download CSV"),
+                        ),
+                        ui.card(
+                            ui.output_data_frame("ai_chat_table"),
+                            full_screen=True,
+                        ),
+                    ),
+                    ui.layout_column_wrap(
+                        ui.card(
+                            ui.card_header("Top Industries by Average Starting Salary (USD)"),
+                            output_widget("ai_industries_bar"),
+                            full_screen=True,
+                        ),
+                        ui.card(
+                            ui.card_header("Average Yearly Starting Salary (USD)"),
+                            output_widget("ai_study_salary_plot"),
+                            full_screen=True
+                        ),
+                        width=1,
+                    ),
+                    col_widths=(6, 6),
+                ),
             ),
-            fillable=True,
-        ),
-        FOOTER,
+            FOOTER
+        )
     )
+
 
 def ai_tab_server(input, output, session):
     """
@@ -112,14 +138,110 @@ def ai_tab_server(input, output, session):
     @render.text
     def ai_chat_title():
         return qc_vals.title() or "Graduate Employability Dataset"
-    
+
     @render.data_frame
     def ai_chat_table():
         return qc_vals.df()
-    
+
     @render.download(filename="graduate_employability_filtered.csv")
     def download_data():
         yield qc_vals.df().to_csv(index=False)
-    
-    # Expose qc_vals so app.py can use the filtered df
+
+    @render_altair
+    def ai_industries_bar():
+        data = qc_vals.df()
+
+        industry_salary = data.groupby("Top_Industry", as_index=False).agg(
+            avg_salary=("Average_Starting_Salary_USD", "mean")
+        )
+
+        industry_salary["rank"] = (
+            industry_salary["avg_salary"]
+            .rank(method="dense", ascending=False)
+            .astype(int)
+        )
+
+        top_industries = industry_salary.sort_values(
+            "avg_salary", ascending=False
+        ).copy()
+
+        industries_bar = (
+            alt.Chart(top_industries)
+            .mark_bar()
+            .encode(
+                y=alt.Y("Top_Industry:N", sort=None, title=None),
+                x=alt.X("avg_salary:Q", title=None, axis=alt.Axis(format="$,.0f")),
+                color=alt.Color("Top_Industry:N", title="Industry", legend=None),
+                tooltip=[
+                    alt.Tooltip("rank:Q", title="Rank"),
+                    alt.Tooltip("Top_Industry:N", title="Industry"),
+                    alt.Tooltip("avg_salary:Q", title="Avg Salary (USD)", format="$,.2f"),
+                ],
+            )
+            .properties(
+                width="container",
+                height="container",
+            )
+        )
+
+        return industries_bar
+
+    @render_altair
+    def ai_study_salary_plot():
+        data = qc_vals.df()
+
+        salary_over_time = data.groupby(
+            ["Graduation_Year", "Field_of_Study"], as_index=False
+        ).agg(avg_salary=("Average_Starting_Salary_USD", "mean"))
+
+        highlight = alt.selection_point(fields=["Field_of_Study"], bind="legend")
+
+        ymin, ymax = (
+            salary_over_time["avg_salary"].min() * 0.95,
+            salary_over_time["avg_salary"].max() * 1.05
+        )
+
+        line_chart = (
+            alt.Chart(salary_over_time)
+            .mark_line(point=True)
+            .encode(
+                x=alt.X(
+                    "Graduation_Year:O",
+                    title=None,
+                    sort="ascending",
+                    axis=alt.Axis(labelAngle=0)
+                ),
+                y=alt.Y(
+                    "avg_salary:Q",
+                    title=None,
+                    axis=alt.Axis(format="$,.0f"),
+                    scale=alt.Scale(domain=[ymin, ymax]),
+                ),
+                color=alt.Color(
+                    "Field_of_Study:N",
+                    title="Field of Study",
+                    legend=alt.Legend(
+                        orient="top",
+                        direction="horizontal",
+                        columns=3
+                    )
+                ),
+                opacity=alt.condition(highlight, alt.value(1), alt.value(0.12)),
+                tooltip=[
+                    alt.Tooltip("Graduation_Year:O", title="Year"),
+                    alt.Tooltip("Field_of_Study:N", title="Field of Study"),
+                    alt.Tooltip(
+                        "avg_salary:Q", title="Avg Salary (USD)", format="$,.2f"
+                    ),
+                ],
+            )
+            .add_params(highlight)
+            .properties(
+                width="container",
+                height="container",
+            )
+        )
+        return line_chart
+
+# Expose qc_vals so app.py can use the filtered df
     return qc_vals

--- a/src/app.py
+++ b/src/app.py
@@ -187,9 +187,10 @@ app_ui = ui.page_navbar(
                     ui.accordion_panel(
                         "Region",
                         (
+                            ui.input_checkbox("region_all", "Select All", True),
                             ui.input_checkbox_group(
                                 id="region",
-                                label="Region",
+                                label=None,
                                 choices=regions,
                                 selected=regions,
                             )
@@ -198,9 +199,10 @@ app_ui = ui.page_navbar(
                     ui.accordion_panel(
                         "Country",
                         (
+                            ui.input_checkbox("country_all", "Select All", True),
                             ui.input_checkbox_group(
                                 id="country",
-                                label="Country",
+                                label=None,
                                 choices=[],
                                 selected=[],
                             )
@@ -209,9 +211,10 @@ app_ui = ui.page_navbar(
                     ui.accordion_panel(
                         "Field of Study",
                         (
+                            ui.input_checkbox("study_all", "Select All", True),
                             ui.input_checkbox_group(
                                 id="study",
-                                label="Study",
+                                label=None,
                                 choices=studies,
                                 selected=studies,
                             )
@@ -222,7 +225,7 @@ app_ui = ui.page_navbar(
                         (
                             ui.input_checkbox_group(
                                 id="degree",
-                                label="Degree",
+                                label=None,
                                 choices=degrees,
                                 selected=degrees,
                             )
@@ -231,9 +234,10 @@ app_ui = ui.page_navbar(
                     ui.accordion_panel(
                         "Industry",
                         (
+                            ui.input_checkbox("industry_all", "Select All", True),
                             ui.input_checkbox_group(
                                 id="industry",
-                                label="Industry",
+                                label=None,
                                 choices=industries,
                                 selected=industries,
                             )
@@ -727,6 +731,105 @@ def server(input, output, session):
             ui.update_accordion(
                 "sidebar_panels",
                 show=False
+            )
+
+    # # aware that this code needs to be refactored, however,
+    # # wanted concepted to be available on dashboard
+
+    # region
+    @reactive.effect
+    @reactive.event(input.region_all)
+    def _():
+        if input.region_all():
+            ui.update_checkbox_group(
+                "region",
+                selected=regions
+            )
+        else:
+            ui.update_checkbox_group(
+                "region",
+                selected=[]
+            )
+
+    @reactive.effect
+    @reactive.event(input.region)
+    def _():
+        if set(input.region()) == set(regions):
+            ui.update_checkbox(
+                "region_all",
+                value=True
+            )
+
+    # country
+    @reactive.effect
+    @reactive.event(input.country_all)
+    def _():
+        if input.country_all():
+            ui.update_checkbox_group(
+                "country",
+                selected=raw_data["Country"].dropna().unique().tolist()
+            )
+        else:
+            ui.update_checkbox_group(
+                "country",
+                selected=[]
+            )
+
+    @reactive.effect
+    @reactive.event(input.country)
+    def _():
+        if set(input.country()) == set(regions):
+            ui.update_checkbox(
+                "country_all",
+                value=True
+            )
+
+    # study
+    @reactive.effect
+    @reactive.event(input.study_all)
+    def _():
+        if input.study_all():
+            ui.update_checkbox_group(
+                "study",
+                selected=studies
+            )
+        else:
+            ui.update_checkbox_group(
+                "study",
+                selected=[]
+            )
+
+    @reactive.effect
+    @reactive.event(input.study)
+    def _():
+        if set(input.study()) == set(studies):
+            ui.update_checkbox(
+                "study_all",
+                value=True
+            )
+
+    # industry
+    @reactive.effect
+    @reactive.event(input.industry_all)
+    def _():
+        if input.industry_all():
+            ui.update_checkbox_group(
+                "industry",
+                selected=industries
+            )
+        else:
+            ui.update_checkbox_group(
+                "industry",
+                selected=[]
+            )
+
+    @reactive.effect
+    @reactive.event(input.industry)
+    def _():
+        if set(input.industry()) == set(industries):
+            ui.update_checkbox(
+                "industry_all",
+                value=True
             )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -181,6 +181,8 @@ app_ui = ui.page_navbar(
         ),
         ui.layout_sidebar(
             ui.sidebar(
+                ui.input_action_button("reset_btn", "Reset Filters"),
+                ui.input_switch("sidebar_switch", "Open/Close Dropdowns"),
                 ui.accordion(
                     ui.accordion_panel(
                         "Region",
@@ -237,8 +239,8 @@ app_ui = ui.page_navbar(
                             )
                         ),
                     ),
+                    id="sidebar_panels",
                     open=False
-                    
                 ),
                 ui.input_slider(
                     id="grad_year",
@@ -254,7 +256,6 @@ app_ui = ui.page_navbar(
                     animate=True,
                     sep="",
                 ),
-                ui.input_action_button("reset_btn", "Reset Filters"),
                 width=300
             ),
             ui.layout_columns(
@@ -713,6 +714,20 @@ def server(input, output, session):
         data = filter_data_by_university()
         req(not data.empty, cancel_output=True)
         return data
+
+    @reactive.effect
+    @reactive.event(input.sidebar_switch)
+    def _():
+        if input.sidebar_switch():
+            ui.update_accordion(
+                "sidebar_panels",
+                show=True
+            )
+        else:
+            ui.update_accordion(
+                "sidebar_panels",
+                show=False
+            )
 
 
 app = App(app_ui, server)

--- a/src/app.py
+++ b/src/app.py
@@ -168,14 +168,16 @@ FOOTER = ui.p(
 )
 
 app_ui = ui.page_navbar(
-    ui.nav_panel("Dashboard",
+    ui.nav_panel(
+        "Dashboard",
         ui.accordion(
             ui.accordion_panel(
-                "About this dashboard",
+                "Click to learn more about this dashboard.",
                 ui.card(
                     ui.markdown(dashboard_description)
                 ),
             ),
+            open=False
         ),
         ui.layout_sidebar(
             ui.sidebar(


### PR DESCRIPTION
Hi team,

The two output components have been added to the LLM page - similar to our main page. However, I did make some stylistic updates on these to make the charts 'cleaner'. If we want, we can do something similar on the front page. I did troubleshoot for a while trying to get everything to be on one page without overflowing and having to scroll, however, this may be a question I have to ask Ilya/TA. I left the dataframe with all the columns, as it's my assumption that this is what they wanted to see and check the chatbot with. I tried several questions and the dataframe and charts update. The download CSV also works for me.

I wanted to get more hands on with Shiny so I made a few changes on the main page. I collapsed the about section upon load. I was thinking of a user (and myself!) and found that each time I opened the dashboard I had to close this. For user experience, think it's best closed initially (but can change if others think otherwise)!

Again for user experience the filter button got moved up. I've also added a toggle to open and close all the dropdowns. You'll also see that the checkbox filters have "Select All" options now except for 'degree_level' since there's only three options. This section in the code can probably be refactored into a function but I had issues properly referencing things and wanted to get the idea on the dashboard.

