### PR TITLE
Fix AI Assistant tab layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Moved AI Assistant tab chat sidebar to the right side of the layout for better visibility of outputs. @apoorva43
 - Reordered AI Assistant tab layout so charts appear above the dataframe table. @apoorva43
 - Moved Download CSV button to the right of the dataframe card header for cleaner presentation. @apoorva43
+- **Addressed:** AI Assistant tab chat sidebar not static and non-intuitive layout ([#94](https://github.com/UBC-MDS/DSCI-532_2026_12_GradSkills/issues/94), [#95](https://github.com/UBC-MDS/DSCI-532_2026_12_GradSkills/issues/95)) via [#99](https://github.com/UBC-MDS/DSCI-532_2026_12_GradSkills/pull/99).
 
 - <!-- Spec or design deviations, and motivation. -->
 - <!-- Feedback items you addressed: "Addressed: <item description> (#<prioritization issue>) via #<PR>" -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added packages to requirements.txt for lazy loading (ibis and DuckDB). @beardw
+- Added packages to `requirements.txt` for lazy loading (ibis and DuckDB). @beardw
 
 - <!-- New features, components, tests - one line each. Reference PRs where relevant (e.g. #12). -->
 
 ### Changed
 
-- Updated app.py to lazy loading using parquet and DuckDB @beardw
+- Updated `app.py` to lazy loading using parquet and DuckDB @beardw
 - Refactored several parts of the codebase to account for parquet formatting of data. @beardw
-- Updated ai_tab.py to lazy loading using parquet and DuckDB @beardw
+- Updated `ai_tab.py` to lazy loading using parquet and DuckDB @beardw
+- Moved AI Assistant tab chat sidebar to the right side of the layout for better visibility of outputs. @apoorva43
+- Reordered AI Assistant tab layout so charts appear above the dataframe table. @apoorva43
+- Moved Download CSV button to the right of the dataframe card header for cleaner presentation. @apoorva43
 
 - <!-- Spec or design deviations, and motivation. -->
 - <!-- Feedback items you addressed: "Addressed: <item description> (#<prioritization issue>) via #<PR>" -->
@@ -24,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Corrected any assignment of the underscore character that interferred with ibis capabilities. @beardw
 - Fixed `ai_tab` import error on Posit Cloud using try/except for relative vs absolute import compatibility. @apoorva43
 - Fixed missing pip dependencies (pyarrow, pyarrow-hotfix, duckdb, ibis-framework) in `environment.yml`. @apoorva43
+- Fixed AI Assistant tab chat sidebar to have a fixed height with internal scrolling so the input box remains visible during long conversations. @apoorva43
 
 - **Feedback prioritization issue link:** #...
 

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -91,8 +91,12 @@ def ai_tab_ui():
         "AI Assistant",
         ui.page_fillable(
             ui.layout_sidebar(
-                qc.sidebar(position="right"),
-
+                qc.sidebar(
+                    width=400,
+                    open="always",
+                    position="right",
+                    style="height: 85vh; overflow-y: auto;",
+                ),
                 ui.layout_columns(
                     ui.card(
                         ui.card_header(
@@ -121,7 +125,7 @@ def ai_tab_ui():
                 ),
             ),
             FOOTER
-        )
+        ),
     )
 
 

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -114,8 +114,11 @@ def ai_tab_ui():
                 ),
                 ui.card(
                     ui.card_header(
-                        ui.output_text("ai_chat_title"),
-                        ui.download_button("download_data", "Download CSV"),
+                        ui.div(
+                            ui.output_text("ai_chat_title"),
+                            ui.download_button("download_data", "Download CSV"),
+                            style="display: flex; justify-content: space-between; align-items: center; width: 100%;",
+                        ),
                     ),
                     ui.output_data_frame("ai_chat_table"),
                     full_screen=True,

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -99,32 +99,29 @@ def ai_tab_ui():
                 ),
                 ui.layout_columns(
                     ui.card(
-                        ui.card_header(
-                            ui.output_text("ai_chat_title"),
-                            ui.download_button("download_data", "Download CSV"),
-                        ),
-                        ui.card(
-                            ui.output_data_frame("ai_chat_table"),
-                            full_screen=True,
-                        ),
+                        ui.card_header("Top Industries by Average Starting Salary (USD)"),
+                        output_widget("ai_industries_bar"),
+                        full_screen=True,
+                        style="height: 350px;",
                     ),
-                    ui.layout_column_wrap(
-                        ui.card(
-                            ui.card_header("Top Industries by Average Starting Salary (USD)"),
-                            output_widget("ai_industries_bar"),
-                            full_screen=True,
-                        ),
-                        ui.card(
-                            ui.card_header("Average Yearly Starting Salary (USD)"),
-                            output_widget("ai_study_salary_plot"),
-                            full_screen=True
-                        ),
-                        width=1,
+                    ui.card(
+                        ui.card_header("Average Yearly Starting Salary (USD)"),
+                        output_widget("ai_study_salary_plot"),
+                        full_screen=True,
+                        style="height: 350px;"
                     ),
                     col_widths=(6, 6),
                 ),
+                ui.card(
+                    ui.card_header(
+                        ui.output_text("ai_chat_title"),
+                        ui.download_button("download_data", "Download CSV"),
+                    ),
+                    ui.output_data_frame("ai_chat_table"),
+                    full_screen=True,
+                ),
             ),
-            FOOTER
+            FOOTER,
         ),
     )
 

--- a/src/ai_tab.py
+++ b/src/ai_tab.py
@@ -91,7 +91,7 @@ def ai_tab_ui():
         "AI Assistant",
         ui.page_fillable(
             ui.layout_sidebar(
-                qc.sidebar(),
+                qc.sidebar(position="right"),
 
                 ui.layout_columns(
                     ui.card(


### PR DESCRIPTION
Hey guys! Addressing the TA feedback on the AI Assistant tab layout:

- Fix the LLM chat sidebar - set fixed height (`85vh`) with internal scrolling so the input box stays visible during long conversations. Moved chat sidebar to the right side of the layout. 
- Modify the AI Assistant tab layout - reordered outputs so charts appear above the dataframe table. Moved Download CSV button to the right of the card header for cleaner presentation.
- Confirmed working locally and at https://019cdb05-3dd4-da21-b51c-5e4d3f68923d.share.connect.posit.cloud/

Closes #94 and #95 